### PR TITLE
fix gcc 7.2 compiler errors

### DIFF
--- a/sql-common/client_authentication.cc
+++ b/sql-common/client_authentication.cc
@@ -84,7 +84,7 @@ RSA *rsa_init(MYSQL *mysql)
 
   if (mysql->options.extension != NULL &&
       mysql->options.extension->server_public_key_path != NULL &&
-      mysql->options.extension->server_public_key_path != '\0')
+      mysql->options.extension->server_public_key_path[0] != '\0')
   {
     pub_key_file= fopen(mysql->options.extension->server_public_key_path,
                         "r");

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -3289,7 +3289,7 @@ static int replace_user_table(THD *thd, TABLE *table, LEX_USER *combo,
       * An empty password is considered to be of mysql_native type.
     */
     
-    if (combo->plugin.str == NULL || combo->plugin.str == '\0')
+    if (combo->plugin.str == NULL || combo->plugin.str[0] == '\0')
     {
       if (combo->uses_identified_by_password_clause)
       {


### PR DESCRIPTION
Example error:
percona_server/sql/sql_acl.cc:3292:59: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
     if (combo->plugin.str == NULL || combo->plugin.str == '\0')
                                                           ^~~~
Apply the fixes from upstream in https://github.com/percona/percona-server/commit/4e0c0d69b191eab90ea75244fda421066c319745.