### PR TITLE
make percona work with openssl 1.1

### DIFF
--- a/mysys_ssl/my_aes_openssl.cc
+++ b/mysys_ssl/my_aes_openssl.cc
@@ -108,7 +108,9 @@ int my_aes_encrypt(const unsigned char *source, uint32 source_length,
                    const unsigned char *key, uint32 key_length,
                    enum my_aes_opmode mode, const unsigned char *iv)
 {
-  EVP_CIPHER_CTX ctx;
+  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+  if (unlikely(!ctx))
+    return MY_AES_BAD_DATA;
   const EVP_CIPHER *cipher= aes_evp_type(mode);
   int u_len, f_len;
   /* The real key to be used for encryption */
@@ -116,30 +118,32 @@ int my_aes_encrypt(const unsigned char *source, uint32 source_length,
   my_aes_create_key(key, key_length, rkey, mode);
 
   if (!cipher || (EVP_CIPHER_iv_length(cipher) > 0
-                  && EVP_CIPHER_mode(cipher) != EVP_CIPH_ECB_MODE && !iv))
+                  && EVP_CIPHER_mode(cipher) != EVP_CIPH_ECB_MODE && !iv)) {
+    EVP_CIPHER_CTX_free(ctx);
     return MY_AES_BAD_DATA;
+  }
 
-  if (!EVP_EncryptInit(&ctx, cipher, rkey, iv))
+  if (!EVP_EncryptInit(ctx, cipher, rkey, iv))
     goto aes_error;                             /* Error */
-  if (!EVP_CIPHER_CTX_set_padding(&ctx, 1))
+  if (!EVP_CIPHER_CTX_set_padding(ctx, 1))
     goto aes_error;                             /* Error */
   if (source_length > 0) /* workaround for old OpenSSL versions */
   {
-    if (!EVP_EncryptUpdate(&ctx, dest, &u_len, source, source_length))
+    if (!EVP_EncryptUpdate(ctx, dest, &u_len, source, source_length))
       goto aes_error;                             /* Error */
   }
   else
     u_len= 0;
-  if (!EVP_EncryptFinal(&ctx, dest + u_len, &f_len))
+  if (!EVP_EncryptFinal(ctx, dest + u_len, &f_len))
     goto aes_error;                             /* Error */
 
-  EVP_CIPHER_CTX_cleanup(&ctx);
+  EVP_CIPHER_CTX_free(ctx);
   return u_len + f_len;
 
 aes_error:
   /* need to explicitly clean up the error if we want to ignore it */
   ERR_clear_error();
-  EVP_CIPHER_CTX_cleanup(&ctx);
+  EVP_CIPHER_CTX_free(ctx);
   return MY_AES_BAD_DATA;
 }
 
@@ -150,7 +154,9 @@ int my_aes_decrypt(const unsigned char *source, uint32 source_length,
                    enum my_aes_opmode mode, const unsigned char *iv)
 {
 
-  EVP_CIPHER_CTX ctx;
+  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+  if (unlikely(!ctx))
+    return MY_AES_BAD_DATA;
   const EVP_CIPHER *cipher= aes_evp_type(mode);
   int u_len, f_len;
 
@@ -159,27 +165,29 @@ int my_aes_decrypt(const unsigned char *source, uint32 source_length,
 
   my_aes_create_key(key, key_length, rkey, mode);
   if (!cipher || (EVP_CIPHER_iv_length(cipher) > 0
-                  && EVP_CIPHER_mode(cipher) != EVP_CIPH_ECB_MODE && !iv))
+                  && EVP_CIPHER_mode(cipher) != EVP_CIPH_ECB_MODE && !iv)) {
+    EVP_CIPHER_CTX_free(ctx);
     return MY_AES_BAD_DATA;
+  }
 
-  EVP_CIPHER_CTX_init(&ctx);
+  EVP_CIPHER_CTX_init(ctx);
 
-  if (!EVP_DecryptInit(&ctx, aes_evp_type(mode), rkey, iv))
+  if (!EVP_DecryptInit(ctx, aes_evp_type(mode), rkey, iv))
     goto aes_error;                             /* Error */
-  if (!EVP_CIPHER_CTX_set_padding(&ctx, 1))
+  if (!EVP_CIPHER_CTX_set_padding(ctx, 1))
     goto aes_error;                             /* Error */
-  if (!EVP_DecryptUpdate(&ctx, dest, &u_len, source, source_length))
+  if (!EVP_DecryptUpdate(ctx, dest, &u_len, source, source_length))
     goto aes_error;                             /* Error */
-  if (!EVP_DecryptFinal_ex(&ctx, dest + u_len, &f_len))
+  if (!EVP_DecryptFinal_ex(ctx, dest + u_len, &f_len))
     goto aes_error;                             /* Error */
 
-  EVP_CIPHER_CTX_cleanup(&ctx);
+  EVP_CIPHER_CTX_free(ctx);
   return u_len + f_len;
 
 aes_error:
   /* need to explicitly clean up the error if we want to ignore it */
   ERR_clear_error();
-  EVP_CIPHER_CTX_cleanup(&ctx);
+  EVP_CIPHER_CTX_free(ctx);
   return MY_AES_BAD_DATA;
 }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4640,9 +4640,6 @@ static void openssl_lock(int mode, openssl_lock_t *lock, const char *file,
 static int init_ssl()
 {
 #ifdef HAVE_OPENSSL
-#ifndef HAVE_YASSL
-  OPENSSL_malloc_init();
-#endif
   ssl_start();
 #ifndef EMBEDDED_LIBRARY
   if (opt_use_ssl)

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1283,7 +1283,7 @@ char *opt_ssl_ca= NULL, *opt_ssl_capath= NULL, *opt_ssl_cert= NULL,
 
 #ifdef HAVE_OPENSSL
 #include <openssl/crypto.h>
-#ifndef HAVE_YASSL
+#if !defined(HAVE_YASSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
 typedef struct CRYPTO_dynlock_value
 {
   mysql_rwlock_t lock;
@@ -2067,7 +2067,7 @@ static void clean_up_mutexes()
   mysql_mutex_destroy(&LOCK_connection_count);
 #ifdef HAVE_OPENSSL
   mysql_mutex_destroy(&LOCK_des_key_file);
-#ifndef HAVE_YASSL
+#if !defined(HAVE_YASSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
   for (int i= 0; i < CRYPTO_num_locks(); ++i)
     mysql_rwlock_destroy(&openssl_stdlocks[i].lock);
   OPENSSL_free(openssl_stdlocks);
@@ -3042,7 +3042,6 @@ bool one_thread_per_connection_end(THD *thd, bool block_pthread)
 
   // Clean up errors now, before possibly waiting for a new connection.
 #ifndef EMBEDDED_LIBRARY
-  ERR_remove_state(0);
 #endif
 
   delete thd;
@@ -4518,7 +4517,7 @@ static int init_thread_environment()
 #ifdef HAVE_OPENSSL
   mysql_mutex_init(key_LOCK_des_key_file,
                    &LOCK_des_key_file, MY_MUTEX_INIT_FAST);
-#ifndef HAVE_YASSL
+#if !defined(HAVE_YASSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
   openssl_stdlocks= (openssl_lock_t*) OPENSSL_malloc(CRYPTO_num_locks() *
                                                      sizeof(openssl_lock_t));
   for (int i= 0; i < CRYPTO_num_locks(); ++i)
@@ -4569,7 +4568,7 @@ static int init_thread_environment()
 }
 
 
-#if defined(HAVE_OPENSSL) && !defined(HAVE_YASSL)
+#if defined(HAVE_OPENSSL) && !defined(HAVE_YASSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
 static unsigned long openssl_id_function()
 {
   return (unsigned long) pthread_self();
@@ -4642,7 +4641,7 @@ static int init_ssl()
 {
 #ifdef HAVE_OPENSSL
 #ifndef HAVE_YASSL
-  CRYPTO_malloc_init();
+  OPENSSL_malloc_init();
 #endif
   ssl_start();
 #ifndef EMBEDDED_LIBRARY
@@ -4656,7 +4655,6 @@ static int init_ssl()
 					  opt_ssl_cipher, &error,
                                           opt_ssl_crl, opt_ssl_crlpath);
     DBUG_PRINT("info",("ssl_acceptor_fd: 0x%lx", (long) ssl_acceptor_fd));
-    ERR_remove_state(0);
     if (!ssl_acceptor_fd)
     {
       sql_print_warning("Failed to setup SSL");

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -5002,7 +5002,6 @@ err:
   mysql_mutex_unlock(&mi->run_lock);
   DBUG_LEAVE;                                   // Must match DBUG_ENTER()
   my_thread_end();
-  ERR_remove_state(0);
   pthread_exit(0);
   return(0);                                    // Avoid compiler warnings
 }
@@ -5193,7 +5192,6 @@ err:
   }
 
   my_thread_end();
-  ERR_remove_state(0);
   pthread_exit(0);
   DBUG_RETURN(0); 
 }
@@ -6357,7 +6355,6 @@ llstr(rli->get_group_master_log_pos(), llbuff));
 
   DBUG_LEAVE;                            // Must match DBUG_ENTER()
   my_thread_end();
-  ERR_remove_state(0);
   pthread_exit(0);
   return 0;                             // Avoid compiler warnings
 }

--- a/vio/vio.c
+++ b/vio/vio.c
@@ -395,7 +395,6 @@ void vio_end(void)
   yaSSL_CleanUp();
 #elif defined(HAVE_OPENSSL)
   // This one is needed on the client side
-  ERR_remove_state(0);
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -66,15 +66,22 @@ static unsigned char dh2048_g[]={
 static DH *get_dh2048(void)
 {
   DH *dh;
-  if ((dh=DH_new()))
-  {
-    dh->p=BN_bin2bn(dh2048_p,sizeof(dh2048_p),NULL);
-    dh->g=BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL);
-    if (! dh->p || ! dh->g)
-    {
-      DH_free(dh);
-      dh=0;
-    }
+  BIGNUM* p = BN_bin2bn(dh2048_p,sizeof(dh2048_p),NULL);
+  if (!p)
+    return 0;
+  BIGNUM* g = BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL);
+  if (!g) {
+    BN_free(p);
+  }
+  dh = DH_new();
+  if (!dh) {
+    BN_free(p);
+    BN_free(g);
+  }
+  if (!DH_set0_pqg(dh, p, NULL, g)) {
+    DH_free(dh);
+    BN_free(p);
+    BN_free(g);
   }
   return(dh);
 }

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -80,8 +80,6 @@ static DH *get_dh2048(void)
   }
   if (!DH_set0_pqg(dh, p, NULL, g)) {
     DH_free(dh);
-    BN_free(p);
-    BN_free(g);
   }
   return(dh);
 }


### PR DESCRIPTION
Based on https://github.com/percona/percona-server/commit/dddeabde2fc7f6896347d69a35880ab236498ee3.
However, we can simplify a bit because we don't care about supporting truly ancient OpenSSL versions.

This can be dropped on upgrade.