### PR TITLE
Stop setting IP_TOS socket option

### DIFF
--- a/vio/viosocket.c
+++ b/vio/viosocket.c
@@ -399,13 +399,6 @@ int vio_fastsend(Vio * vio __attribute__((unused)))
   int r=0;
   DBUG_ENTER("vio_fastsend");
 
-#if defined(IPTOS_THROUGHPUT)
-  {
-    int tos = IPTOS_THROUGHPUT;
-    r= mysql_socket_setsockopt(vio->mysql_socket, IPPROTO_IP, IP_TOS,
-	                           (void *)&tos, sizeof(tos));
-  }
-#endif                                    /* IPTOS_THROUGHPUT */
   if (!r)
   {
 #ifdef __WIN__


### PR DESCRIPTION
IPTOS_THROUGHPUT is 0x8 https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/ip.h#L26 and internally our router converts that to Best-effort. We don't want that. So simply using the default 0x0 should work out fine.