### PR TITLE
Stop setting IP_TOS socket option

### DIFF
--- a/vio/viosocket.c
+++ b/vio/viosocket.c
@@ -411,13 +411,6 @@ int vio_fastsend(Vio * vio MY_ATTRIBUTE((unused)))
   int r=0;
   DBUG_ENTER("vio_fastsend");
 
-#if defined(IPTOS_THROUGHPUT)
-  {
-    int tos = IPTOS_THROUGHPUT;
-    r= mysql_socket_setsockopt(vio->mysql_socket, IPPROTO_IP, IP_TOS,
-	                           (void *)&tos, sizeof(tos));
-  }
-#endif                                    /* IPTOS_THROUGHPUT */
   if (!r)
   {
 #ifdef _WIN32


### PR DESCRIPTION
IPTOS_THROUGHPUT is 0x8 https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/ip.h#L26 and internally our router converts that to Best-effort. We don't want that. So simply using the default 0x0 should work out fine.